### PR TITLE
Use ex_pty

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,8 +21,7 @@ defmodule NervesSSHShell.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:nerves_runtime_shell, "~> 0.1.0"},
-      {:erlexec, github: "saleyn/erlexec", tag: "7f12101e5e7128d9a442974060cec81c90db71ef"}
+      {:ex_pty, github: "SteffenDE/ex_pty", branch: "main"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,4 @@
 %{
-  "erlexec": {:git, "https://github.com/saleyn/erlexec.git", "7f12101e5e7128d9a442974060cec81c90db71ef", [tag: "7f12101e5e7128d9a442974060cec81c90db71ef"]},
+  "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
+  "ex_pty": {:git, "https://github.com/SteffenDE/ex_pty.git", "49a8300f3c97f969e7e9d753a0c134ea2c1adf71", [branch: "main"]},
 }


### PR DESCRIPTION
This PR replaces erlexec with [ex_pty](https://github.com/SteffenDE/ex_pty), that is currently not feature complete but strives to be a minimal port for pseudo terminals.